### PR TITLE
Restricts Grav-Adapted Humans, newlines promie blurb

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -8,7 +8,7 @@
 	oxygen requirements to support their robust metabolism."
 	icobase = 'icons/mob/human_races/subspecies/r_gravworlder.dmi'
 	health_hud_intensity = 3
-
+	spawn_flags = SPECIES_IS_RESTRICTED
 	flash_mod =     0.9
 	oxy_mod =       1.1
 	radiation_mod = 0.5

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -5,7 +5,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 
 	name =             "Promethean"
 	name_plural =      "Prometheans"
-	blurb =            "A strange species made of slime, identical to their primitive counterparts with the exception that they are not only sentient, but can also maintain a humanoid shape, which they may change at will. While it's been theorized that their color determines their personality, there is no scientific backing to this statement. What is clear, though, is that sudden bursts of energy, burns, and even water will cause a Promethean to dissolve violently."
+	blurb =            "A strange species made of slime, identical to their primitive counterparts with the \
+	exception that they are not only sentient, but can also maintain a humanoid shape, which they may change at \
+	will. While it's been theorized that their color determines their personality, there is no scientific backing \
+	to this statement. What is clear, though, is that sudden bursts of energy, burns, and even water will cause a Promethean to dissolve violently."
 	show_ssd =         "totally quiescent"
 	death_message =    "rapidly loses cohesion, splattering across the ground..."
 	knockout_message = "collapses inwards, forming a disordered puddle of goo."


### PR DESCRIPTION
Teeny weeny changes to the promie blurb, also prevents selecting Grav-Adapted Humans as a race because they're so swole that their shoulders metaphysically extend out of their own shirts. Also any skin tone past 100 makes them pitch black and that's kinda weird.