### PR TITLE
Gives more armor some sounds

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -129,8 +129,8 @@
 				footstepsound = "erikafootsteps"
 
 			if(H.wear_suit)//If they're wearing armor make an armor sound.
-				var/obj/item/clothing/suit/armor/C = H.wear_suit
-				if(istype(C))
+				var/obj/item/clothing/suit/C = H.wear_suit
+				if(istype(C) && C.armor["melee"] > 30)
 					is_wearing_armor = 1
 
 			if(H.shoes)//If they're wearing shoes play some shoe sounds.


### PR DESCRIPTION
What used to be anything under the armor path has been changed to anything with a melee armor rating greater than 30 getting armor sounds whenever you walk around. I should probably adjust this higher. More testing needed.