### PR TITLE
Hacky workaround to missing shuttle chairs

### DIFF
--- a/maps/dreyfus/structures/furniture.dm
+++ b/maps/dreyfus/structures/furniture.dm
@@ -1,7 +1,7 @@
 //bed
 /obj/structure/bed
 	icon = 'maps/dreyfus/icons/furniture.dmi'
-	
+
 //chairs
 /obj/structure/bed/chair/shuttle
 	name = "passenger seat"
@@ -11,6 +11,9 @@
 	icon_state = "shuttle_chair"
 	base_icon = "shuttle_chair"
 	material_alteration = MATERIAL_ALTERATION_NONE
+
+/obj/structure/bed/chair/shuttle/update_icon()
+	return
 
 /obj/structure/bed/chair/white
 	color = null


### PR DESCRIPTION
Just throw a return on there who even cares.
Unfortunately rotating a chair to face north while you're buckled in will fail to hide your character behind the chair. Will make an issue about this.